### PR TITLE
remove channel input (no longer required)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,9 +4,6 @@ inputs:
   review-teams-and-channels:
     description: 'JSON object of review team slugs to channel hashtags.'
     required: true
-  channel:
-    description: 'Channel to send the ping to.'
-    required: true
   api-key:
     description: 'Dialpad API key.'
     required: true


### PR DESCRIPTION
channel input is no longer required and there are no references to it in the code.

channel to message is calculated using the `review-teams-and-channels` input